### PR TITLE
remove ipad default

### DIFF
--- a/sass/_grid-settings.scss
+++ b/sass/_grid-settings.scss
@@ -27,12 +27,6 @@
 
 // register states
 @include gridle_register_default_states();
-@include gridle_register_state(ipad-landscape, (
-	query : "only screen and (min-device-width : 768px) and (max-device-width : 1024px) and (orientation : landscape)",
-	gutter-height : 50px,
-	gutter-width : 60px,
-	direction : rtl
-));
 
 
 // you can set css to be applied on the desired element type (grid here)


### PR DESCRIPTION
The ipad rtl landscape setting is causing me problems.  Could you remove it or make it configureable?
